### PR TITLE
RFC template and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@
 1. You're out if you miss two consecutive meetings without notice.
 1. For now, members of the TSC are coopted.
 1. The chair is elected for one year.
+
+# Slack
+
+AIDA User Group also opened its Slack for Data Contract discussion. It is an alternate way of contributing to this project. The Slack channel is now [available](https://aidaug.slack.com/archives/C05UZRSBKLY).
+
+You have to be a member of AIDA User Group (it's free) to have access to our Slack channel. All the details are [here](https://aidausergroup.org/welcome/).

--- a/rfcs/0000-template.md
+++ b/rfcs/0000-template.md
@@ -29,3 +29,7 @@ Champion:
 ## Consequences
 
 > The consequences of this decision.
+
+## References
+
+> Prior art, inspiration, and other references you used to create this based on what's worked well before.

--- a/rfcs/0000-template.md
+++ b/rfcs/0000-template.md
@@ -1,0 +1,31 @@
+# Title
+
+> The champion is the person who is primarily supporting the RFC.
+
+Champion: 
+
+## Summary
+
+> One paragraph explanation of the RFC.
+
+## Motivation
+
+> Why are we doing this? What use cases does it support? What is the expected outcome?
+> How does it align with our guiding values?
+
+## Design and examples
+
+> This is the bulk of the RFC.
+> Explain the design in enough detail for somebody familiar with data contracts and the standard to understand. This should get into specifics and corner-cases, and include examples of how this is to be used.
+
+## Alternatives
+
+> Rejected alternative solutions and the reasons why.
+
+## Decision
+
+> The decision made by the TSC.
+
+## Consequences
+
+> The consequences of this decision.

--- a/rfcs/0004-rename-table.md
+++ b/rfcs/0004-rename-table.md
@@ -2,6 +2,20 @@
 
 - Champion: Andrew Jones
 
+## Summary
+
+The current structure uses `dataset`, `name` and `columns` to define a data contract. However, these are all database terms - or specially, BigQuery terms, and they suggest very clearly an implementation (tables in a data warehouse). We want the data contract to be more generic than that, and suggest we rename these fields to be more generic.
+
+## Motivation
+
+Many of us are using data contracts for more than just the data warehouse. The second most popular technology used is streaming, for example Kafka or Google Pub/Sub. But as a concept, data contracts are not tied to any particular technology - it's more of a pattern to describe data, no matter where that data happens to be.
+
+We want to make the standard reflect that. It should be generic, so as technology changes, the standard remains relevant.
+
+This aligns with our guiding value of interoperability.
+
+## Design and examples
+
 We currently have the following structure:
 
 ```yaml
@@ -21,7 +35,7 @@ Found issues:
 Open Questions:
 - How do we capture other data, like unstructured data (scientific papers in form of PDFs), vectors, ... Do we want to specify unstructured or semistructured data in a data contract?
 
-## Options
+## Alternatives
 
 ### Field and Name
 
@@ -73,3 +87,17 @@ models:
   fields:
     - field: order_id
 ```
+
+## Decision
+
+TBD
+
+## Consequences
+
+This would be a breaking change and therefore should be considered for version 3.
+
+## References
+
+* At GoCardless [we use name](https://medium.com/gocardless-tech/implementing-data-contracts-at-gocardless-3b5c49074d13), and it's working well for both tables and streams. It has not caused any confusion in 3 years of production, despite most users being familiar with the underlying technology and its terms (BigQuery and Pub/Sub)
+* [Protobuf calls them "fields"](https://protobuf.dev/programming-guides/proto3/), as [does Avro](https://avro.apache.org/docs/1.11.1/specification/).
+* [OpenAPI uses "title"](https://spec.openapis.org/oas/latest.html), which could also work well instead of name

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,33 @@
+# RFCs
+
+The RFC (request for comments) process is intended is intended to provide a consistent and controlled path for changes to the Open Data Contract Standard (ODCS) so that all stakeholders can be confident about the direction of the project.
+
+## Table of Contents
+[Table of Contents]: #table-of-contents
+
+  - [Before creating an RFC]
+  - [The process]
+
+## Before creating an RFC
+[Before creating an RFC]: #before-creating-an-rfc
+
+Although there is no single way to prepare for submitting an RFC, it is generally a good idea to pursue feedback from other project developer beforehand, to ascertain that the RFC may be desirable; having a consistent impact on the project requires concerted effort toward consensus-building.
+
+The most common preparations for writing and submitting an RFC include talking the idea over on our Slack channel and using a Google Doc to create the draft.
+
+## The process
+
+- Fork the RFC repo [RFC repository]
+  - Copy `0000-template.md` to `xxxx-my-feature.md`,` where "my-feature" is descriptive, and the number is the next in sequence.
+  - Fill in the RFC.
+  - Submit a pull request. As a pull request the RFC will receive design feedback from the larger community, and the author should be prepared to revise it in response.
+  - Build consensus and integrate feedback. RFCs that have broad support are much more likely to make progress than those that don't receive any comments. Feel free to reach out to the RFC assignee in particular to get help identifying stakeholders and obstacles.
+  - RFCs rarely go through this process unchanged, especially as alternatives and drawbacks are shown. You can make edits, big and small, to the RFC to clarify or change the design, but make changes as new commits to the pull request, and leave a comment on the pull request explaining your changes. Specifically, do not squash or rebase commits after they are visible on the pull request.
+  - When ready, RFCs will be voted on by the TSC at its monthly meeting.
+  - Update the RFC with the decision taken by the TSC.
+  - Merge in the RFC.
+
+## Acknowledgments
+
+* [Rust RFCs](https://github.com/rust-lang/rfcs) - Rust RFC process.
+* [ghostinthewires](https://github.com/ghostinthewires/Rfcs-Template/tree/master) - A RFC process template.


### PR DESCRIPTION
This PR adds a template for RFC's, and documents the process in the README.

I've also refactored RFC 0002 to match this template so it can act as an example (whether accepted or not!).