### PR TITLE
docs: clarify RFC 0043 decision

### DIFF
--- a/rfcs/0043-physical-data-encoding.md
+++ b/rfcs/0043-physical-data-encoding.md
@@ -186,7 +186,9 @@ Rejected for now. An enum would improve validation but risks excluding valid pla
 
 ## Decision
 
-TBD by TSC.
+Accepted by the TSC via RFC PR [#59](https://github.com/bitol-io/tsc/pull/59).
+
+This RFC establishes character encoding as optional metadata for describing physical data payloads in ODCS. The precise ODCS schema placement and implementation scope should be finalized in the ODCS repository before the implementation PR, especially for server-level defaults and dataset/schema-level overrides.
 
 ## Consequences
 


### PR DESCRIPTION
## Summary

- Update RFC 0043's `Decision` section after the RFC PR was merged
- Replace the remaining `TBD by TSC` placeholder with an accepted decision reference
- Keep the ODCS implementation scope explicitly deferred to the ODCS repository, where the server-level vs hybrid placement should be confirmed before implementation

## Context

RFC 0043 was merged in #59, but the document still says `Decision: TBD by TSC`.

I also asked for implementation-scope clarification on the ODCS issue before opening the ODCS implementation PR:
https://github.com/bitol-io/open-data-contract-standard/issues/263#issuecomment-4421886826
