### PR TITLE
rfc(0018/OORS): expand result status enum (error≠fail, skip, warn) + severity orthogonality

### DIFF
--- a/rfcs/0018-oors.md
+++ b/rfcs/0018-oors.md
@@ -82,8 +82,8 @@ Each `result` object contains the following fields:
 | `result.id`                  | Result ID          | `string`              | Yes      | A unique identifier for the specific check/metric. |
 | `result.type`                | Type               | `string`              | Yes      | The type of observation, either `check` (for pass/fail checks) or `metric` (for measured values). |
 | `result.name`                | Name               | `string`              | Yes      | A human-readable name for the check/metric. |
-| `result.status`              | Status             | `string`              | Yes      | The outcome of the observation, either `pass` or `fail`. |
-| `result.severity`            | Severity           | `string`              | No       | The severity level of the observation, e.g., `critical`, `high`, `medium`, `low`, `warning`, etc. |
+| `result.status`              | Status             | `string`              | Yes      | The outcome of the observation: `pass` (executed, met expectation), `fail` (executed, breached a hard threshold), `warn` (executed, breached a soft/warning threshold), `error` (could **not** be evaluated — verdict unknown; e.g. the query failed or the source was unreachable), or `skip` (intentionally not run). `error` is distinct from `fail`: a failure is a known-bad verdict, an error is the *absence* of a verdict and must not be counted as a failure. |
+| `result.severity`            | Severity           | `string`              | No       | The severity level of the observation, e.g., `critical`, `high`, `medium`, `low`, `warning`, etc. Severity is **orthogonal** to `status`: `status` is the runtime outcome, `severity` is the definition-time importance of the check. They compose — a `critical`-severity check with `status: error` is the loudest possible alert (the check you most care about could not even run). |
 | `result.dimension`           | Dimension          | `string`              | No       | The dimension of data quality being observed, e.g., `accuracy`, `completeness`, `consistency`, `timeliness`, `validity`, `uniqueness`, etc. (following ODCS data quality dimensions). |
 | `result.target`              | Target             | `object`              | No       | Object describing the resource being observed. |
 | `result.target.resourceType` | Resource Type      | `string`              | No       | The type of resource, e.g., `table`, `column`, `dataset`, etc. |
@@ -210,6 +210,10 @@ Single observation message with multiple results (and contract reference):
 ```
 
 ### FAQ
+
+**Question:** Why does `status` distinguish `error` from `fail`, and `skip` from both?
+
+**Answer:** A `fail` is a known-bad verdict — the check ran and the data breached its threshold. An `error` is the *absence* of a verdict — the check could not run (query exception, unreachable source, timeout), so we know nothing about the data. Counting an infrastructure error as a data failure poisons dashboards and triggers the wrong remediation. `skip` marks a check that was intentionally not evaluated (filtered out, disabled, or an unmet precondition); its absence must not read as a pass or a fail. Every mature check framework already separates these (Soda: `pass`/`warn`/`fail`/`error`; JUnit: failures vs. errors; TAP: SKIP/TODO directives). The optional `warn` covers a soft breach that should alert without failing a gate.
 
 **Question:** Should OORS support multiple results in a single message (as a `results` array), or require each observation to be sent as its own message?
 


### PR DESCRIPTION
Refines **RFC-0018 (OORS)** result semantics. Two changes, both grounded in existing prior art:

**1. Expand `result.status` from `pass`/`fail` → `pass | fail | warn | error | skip`.**
- `error` ≠ `fail`: a failure is a known-bad verdict; an error is the *absence* of a verdict (query blew up, source unreachable). Counting an infra error as a data failure poisons dashboards and triggers the wrong remediation.
- `skip` marks an intentionally-not-evaluated check; its absence must not read as pass or fail.
- `warn` covers a soft-threshold breach that should alert without failing a gate.
- Prior art: Soda (`pass`/`warn`/`fail`/`error`), JUnit (failures vs errors), TAP (SKIP/TODO).

**2. State that `severity` is orthogonal to `status`** — `status` is the runtime outcome, `severity` is the definition-time importance; they compose. Plus an FAQ entry on the `error`/`fail`/`skip` distinction.

Doc-only change to a draft RFC. Submitting for TSC review per the RFC process — not for self-merge.
