### PR TITLE
rfc(0040/OOCS): adopt ODCS scheduler/schedule + unify measure/dataQuality into evaluate

### DIFF
--- a/rfcs/0040-oocs.md
+++ b/rfcs/0040-oocs.md
@@ -114,8 +114,10 @@ Named action definitions that the sidecar or control plane can execute. Each act
 | --------------------------- | ------ | ----------- | ------------------------------------------------------------------ |
 | `actions[].id`              | string | yes         | Unique identifier within this document. Used for cross-referencing |
 | `actions[].name`            | string | yes         | Human-readable name                                                |
-| `actions[].type`            | enum   | yes         | Action type: `register`, `heartbeat`, `deregister`, `configure`, `measure`, `dataQuality` |
+| `actions[].type`            | enum   | yes         | Action type: `register`, `heartbeat`, `deregister`, `configure`, `evaluate`. (`evaluate` supersedes the earlier `measure` and `dataQuality` types — see *Action type: `evaluate`*.) |
 | `actions[].description`     | string | no          | What this action does                                              |
+| `actions[].scheduler`       | string | no          | Name of the scheduler that fires this action, e.g. `cron` (reuses ODCS RFC-0025 `scheduler`). Omit for actions fired on demand or by lifecycle events (`register` on startup, `deregister` on shutdown). |
+| `actions[].schedule`        | string | conditional | Scheduler configuration; for `cron` a possible value is `30 3 * * *`. Required when `scheduler` is set. Reuses ODCS RFC-0025 `schedule`. |
 | `actions[].response`       | object | yes         | How the emitter is notified about the outcome                      |
 | `actions[].response.type`  | enum   | yes         | Response channel: `kafka`, `rest`                                  |
 | `actions[].response.topic` | string | conditional | Kafka topic for results. Required when `response.type` is `kafka`  |
@@ -142,6 +144,8 @@ Periodic liveness signal to the control center.
 | `actions[].payload.value` | integer | yes      | Numeric interval value                               |
 | `actions[].payload.unit`  | enum    | yes      | Time unit: `s` (seconds), `m` (minutes), `h` (hours) |
 
+> **Note (scheduling reconciliation):** the bespoke `interval` / `payload.{value,unit}` cadence is **deprecated** in favor of the `scheduler` + `schedule` fields (ODCS RFC-0025). A 30-second heartbeat becomes `scheduler: cron` + `schedule: "*/30 * * * * *"`. This gives the whole Bitol family one cadence vocabulary (ODCS data quality, ODCS SLA, OOCS actions) instead of three.
+
 #### Action type: `deregister`
 
 Sent on graceful shutdown to remove a data product from the control center.
@@ -165,27 +169,22 @@ Sent by the control center to a data product to deliver configuration content (e
 | `actions[].payload.version` | string (semver) | yes      | Version of the data product                     |
 | `actions[].payload.content` | string          | yes      | The configuration content (e.g. full ODPS YAML) |
 
-#### Action type: `measure`
+#### Action type: `evaluate`
 
-Requests a measurement (e.g. SLA compliance, freshness, completeness) for a governed artifact. The results are posted back via the `response` channel, typically to an observability platform.
+Requests an evaluation of a governed artifact and reports the outcome via the `response` channel as an OORS (`kind: ObservabilityResults`) document. `evaluate` unifies the earlier `measure` and `dataQuality` types: the `method` field selects the kind of evaluation and `payload.kind` selects what is evaluated. This keeps OOCS symmetric with OORS, which carries a single result shape discriminated by `type`, and means a new evaluation style needs no new action type.
 
-| Field                       | Type            | Required | Description                                         |
-| --------------------------- | --------------- | -------- | --------------------------------------------------- |
-| `actions[].payload`         | object          | yes      | Identifies the artifact to measure                  |
-| `actions[].payload.kind`    | string          | yes      | Artifact type (e.g. `DataContract`)                 |
-| `actions[].payload.id`      | string (UUID)   | yes      | Unique identifier of the artifact                   |
-| `actions[].payload.version` | string (semver) | yes      | Version of the artifact                             |
+| Field                       | Type            | Required | Description                                                                                   |
+| --------------------------- | --------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `actions[].method`          | string          | yes      | How to evaluate: `dataQuality`, `sla`, ... (open vocabulary; `x-` for custom methods) |
+| `actions[].payload`         | object          | yes      | Identifies the artifact to evaluate                                                           |
+| `actions[].payload.kind`    | string          | yes      | Artifact type, e.g. `DataContract`, `DataProduct`                                             |
+| `actions[].payload.id`      | string (UUID)   | yes      | Unique identifier of the artifact                                                             |
+| `actions[].payload.version` | string (semver) | yes      | Version of the artifact                                                                       |
 
-#### Action type: `dataQuality`
+Common `method` / `payload.kind` pairings:
 
-Requests data quality checks for a governed artifact. The results are posted back via the `response` channel, typically to a data quality or remediation tool.
-
-| Field                       | Type            | Required | Description                                         |
-| --------------------------- | --------------- | -------- | --------------------------------------------------- |
-| `actions[].payload`         | object          | yes      | Identifies the artifact to validate                 |
-| `actions[].payload.kind`    | string          | yes      | Artifact type (e.g. `DataContract`)                 |
-| `actions[].payload.id`      | string (UUID)   | yes      | Unique identifier of the artifact                   |
-| `actions[].payload.version` | string (semver) | yes      | Version of the artifact                             |
+- `method: dataQuality` + `payload.kind: DataContract` — run the contract's data quality rules; results return as OORS.
+- `method: sla` + `payload.kind: DataContract` — measure SLA compliance (freshness, completeness, latency).
 
 ### Example 1: Minimal — startup registration and heartbeat
 
@@ -212,12 +211,11 @@ actions:
     name: Periodic liveness check
     type: heartbeat
     description: Send a heartbeat every 30 seconds.
+    scheduler: cron
+    schedule: "*/30 * * * * *"
     response:
       type: kafka
       topic: controlcenter.dataproduct.feedback
-    interval:
-      value: 30
-      unit: s
 ```
 
 ### Example 2: Structured — shutdown with metadata
@@ -310,8 +308,11 @@ tenant: RetailCorp
 actions:
   - id: measure-sla
     name: SLA compliance measurement
-    type: measure
+    type: evaluate
+    method: sla
     description: Measure SLA compliance for the customer data contract and report results to Actian Data Observability.
+    scheduler: cron
+    schedule: "0 6 * * *"
     response:
       type: rest
       url: https://actian-dataobservability.retailcorp.com/api/v1/sla/results
@@ -336,7 +337,8 @@ domain: seller
 actions:
   - id: dq-check
     name: Data quality validation
-    type: dataQuality
+    type: evaluate
+    method: dataQuality
     description: Run data quality rules defined in the contract and send results to JoeThePlumberFixer for remediation.
     response:
       type: rest
@@ -398,6 +400,22 @@ OOCS drives actions; OORS captures results. Should OOCS include an explicit link
 RFC-0039 (OMDS) defines `sourceKind` for `DataContract` and `DataProduct`. Should OMDS also support `sourceKind: OrchestrationControl` for diffing OOCS documents? If so, what impact classification rules apply?
 
 **Recommendation**: Yes, as a future extension to OMDS. Suggested impact rules: removing an action = MAJOR, changing response = MAJOR, changing interval = MINOR, changing description = PATCH.
+
+### OI-8: Scheduling vocabulary
+
+Earlier drafts had no way to express *when* a scheduled action fires — `heartbeat` carried a bespoke `interval` while other actions had nothing. This revision adopts ODCS RFC-0025's `scheduler` + `schedule` fields (approved 2025-08-19, already used by ODCS data quality and SLA checks) on every action, and deprecates `heartbeat.interval`.
+
+**Question**: Should `scheduler`/`schedule` live on the action (as specified here) or on the document with per-action overrides?
+
+**Recommendation**: On the action. Different actions in one document legitimately run on different cadences (a nightly gate vs. an on-demand reconfigure).
+
+### OI-9: `evaluate` vs. discrete `measure` / `dataQuality` / `test`
+
+This revision unifies `measure` and `dataQuality` into a single `evaluate` action discriminated by `method`, so any new evaluation style needs no new action type — mirroring OORS, which carries one result shape discriminated by `type`. The alternative — a discrete action type per evaluation style — was rejected as enum churn.
+
+**Question**: Should `method` be a closed enum or open (with `x-` custom methods, per OI-1)?
+
+**Recommendation**: Open, consistent with OI-1's treatment of action types.
 
 ## Alternatives
 


### PR DESCRIPTION
Refines **RFC-0040 (OOCS)** with two changes:

**1. Scheduling.** Adopt ODCS **RFC-0025**'s ratified `scheduler` + `schedule` (cron) fields on every action — reused verbatim so the whole Bitol family expresses cadence one way (ODCS DQ, ODCS SLA, OOCS actions). Deprecates the bespoke `heartbeat.interval` (a 30s heartbeat becomes `scheduler: cron` + `schedule: "*/30 * * * * *"`).

**2. Unify `measure` + `dataQuality` → one `evaluate` action** discriminated by `method` (`dataQuality`/`sla`/…) and `payload.kind` (`DataContract`/`DataProduct`). Mirrors OORS's single-result-shape-discriminated-by-`type`, so a new evaluation style needs no new action type. Adds OI-8 (scheduling) and OI-9 (evaluate vs discrete actions). Example 4 demonstrates a scheduled SLA evaluate.

Doc-only change to a draft RFC. Submitting for TSC review per the RFC process — not for self-merge.
