### PR TITLE
docs(rfc-0050): clarify Variables applies to all Bitol standards

### DIFF
--- a/rfcs/0050-variables.md
+++ b/rfcs/0050-variables.md
@@ -21,7 +21,7 @@ Applies to:
 
 ## Summary
 
-This RFC standardizes a single, minimal mechanism: any string value in an ODCS data contract MAY contain `${VAR_NAME}` references that are resolved at runtime by tooling. This lets contract authors keep secrets and environment-specific values out of the contract itself, without adding any new section or field to the standard.
+This RFC standardizes a single, minimal mechanism: any string value in a Bitol standard document — ODCS, ODPS, OORS, OOCS, OMMS, or OMDS — MAY contain `${VAR_NAME}` references that are resolved at runtime by tooling. This lets authors keep secrets and environment-specific values out of the document itself, without adding any new section or field to any standard.
 
 ## Motivation
 
@@ -47,7 +47,7 @@ A standard interpolation syntax lets every tool resolve these values the same wa
 
 ## Design and examples
 
-Any string value anywhere in a data contract MAY contain one or more variable references of the form `${VAR_NAME}`. References MAY appear as a whole value or as a substring (for example, `jdbc:postgresql://${DB_HOST}:${DB_PORT}/orders`).
+Any string value anywhere in a Bitol document (data contract, data product, observability results, and the other standards) MAY contain one or more variable references of the form `${VAR_NAME}`. References MAY appear as a whole value or as a substring (for example, `jdbc:postgresql://${DB_HOST}:${DB_PORT}/orders`).
 
 `VAR_NAME` is an identifier chosen by the contract author. This RFC does not constrain the naming convention beyond requiring that it be a valid string within `${...}`.
 


### PR DESCRIPTION
RFC-0050 (Variables) already ticks all six `Applies to` boxes, but the **Summary** and **Design** sections described `${VAR_NAME}` interpolation as applying to "an ODCS data contract" — misleading, since the mechanism is standard-wide.

This is a wording fix only (RFC-0050 is still a draft; Decision is TBD pending the TSC vote). No normative behavior changes.

- Summary: generalized to "a Bitol standard document — ODCS, ODPS, OORS, OOCS, OMMS, or OMDS".
- Design: "in a data contract" → "in a Bitol document (data contract, data product, observability results, …)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adou6Wv1WCxD3JzmMkewvY