### PR TITLE
docs(readme): move RFC-0045 to Approved / ODCS v3.2.0

### DIFF
--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -29,7 +29,6 @@ Proposed or under discussion — not yet approved by the TSC. These are what rem
 | [0039](0039-omds.md) | OMDS: Open Metadata Difference Standard |
 | [0040](0040-oocs.md) | OOCS: Open Orchestration and Control Standard |
 | [0044](0044-osds.md) | OSDS: Open Semantic Definition Standard |
-| [0045](0045-hana-server-type.md) | HANA server type |
 | [0046](0046-sla-custom-properties-and-authoritative-definitions.md) | Custom properties and authoritative definitions for SLAs |
 | [0047](0047-relationship-id.md) | Adding `id` to Relationship Objects |
 | [0048](0048-geometry-geography.md) | Geometry and Geography Data Types |
@@ -83,6 +82,7 @@ Accepted by the TSC and shipped in the standard/version shown. Each links to its
 | [0041](0041-synonyms.md) | Synonyms |
 | [0042](0042-vector-type.md) | Vector Type |
 | [0043](0043-physical-data-encoding.md) | Physical Data Encoding |
+| [0045](0045-hana-server-type.md) | HANA server type |
 | [0051](0051-deprecated-flag.md) | Deprecated flag for schema and properties |
 
 ### ODPS v0.9.0


### PR DESCRIPTION
RFC-0045 (HANA server type) was approved into ODCS v3.2.0 (PR #73) but the RFC dashboard in `rfcs/README.md` still listed it under **Open RFCs**. This moves its row to the **Approved / ODCS v3.2.0** table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adou6Wv1WCxD3JzmMkewvY