### PR TITLE
docs(rfcs): normalize standard RFC titles to "Full Name (ACRONYM)"

### DIFF
--- a/rfcs/0039-omds.md
+++ b/rfcs/0039-omds.md
@@ -1,4 +1,4 @@
-# OMDS: Open Metadata Difference Standard
+# Open Metadata Difference Standard (OMDS)
 
 Champion: Jean-Georges Perrin.
 

--- a/rfcs/0040-oocs.md
+++ b/rfcs/0040-oocs.md
@@ -1,4 +1,4 @@
-# OOCS: Open Orchestration and Control Standard
+# Open Orchestration and Control Standard (OOCS)
 
 Champion: Jean-Georges Perrin.
 

--- a/rfcs/0044-osds.md
+++ b/rfcs/0044-osds.md
@@ -1,4 +1,4 @@
-# OSDS: Open Semantic Definition Standard
+# Open Semantic Definition Standard (OSDS)
 
 Champion: Jean-Georges Perrin.
 

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -26,9 +26,9 @@ Proposed or under discussion — not yet approved by the TSC. These are what rem
 | [0031](0031-relatesTo.md) | Informational Relationship Types |
 | [0032](0032-imports.md) | Imports — Reusing Definitions Across Contracts |
 | [0037](0037-omms.md) | Open Maturity Model Standard (OMMS) |
-| [0039](0039-omds.md) | OMDS: Open Metadata Difference Standard |
-| [0040](0040-oocs.md) | OOCS: Open Orchestration and Control Standard |
-| [0044](0044-osds.md) | OSDS: Open Semantic Definition Standard |
+| [0039](0039-omds.md) | Open Metadata Difference Standard (OMDS) |
+| [0040](0040-oocs.md) | Open Orchestration and Control Standard (OOCS) |
+| [0044](0044-osds.md) | Open Semantic Definition Standard (OSDS) |
 | [0047](0047-relationship-id.md) | Adding `id` to Relationship Objects |
 | [0048](0048-geometry-geography.md) | Geometry and Geography Data Types |
 | [0049](0049-iceberg-server-type.md) | Apache Iceberg server type |


### PR DESCRIPTION
Reformats the titles of three open RFCs from `ACRONYM: Full Name` to `Full Name (ACRONYM)`, to match the convention already used by **RFC-0018 (OORS)** and **RFC-0037 (OMMS)**:

- 0039 → **Open Metadata Difference Standard (OMDS)**
- 0040 → **Open Orchestration and Control Standard (OOCS)**
- 0044 → **Open Semantic Definition Standard (OSDS)**

Each RFC's H1 and its row in the `rfcs/README.md` dashboard are updated.

Scope check: the `ACRONYM - Full Name` strings in every RFC's `Applies to:` checklist are a separate, consistent labeling convention (used in the template and all RFCs) and are intentionally left unchanged. No references to these titles exist in the standard repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adou6Wv1WCxD3JzmMkewvY