### PR TITLE
docs(rfcs): fix broken links in open draft RFCs

### DIFF
--- a/rfcs/0032-imports.md
+++ b/rfcs/0032-imports.md
@@ -1002,9 +1002,9 @@ Key observations:
 
 Import sources do not have to be data contracts. Organizations can maintain shared definition files with a different `kind` — a centralized library of reusable structures, quality rules, and templates that any contract can import from.
 
-This example uses the companion file [`0032-shared-definitions.yaml`](0032-shared-definitions.yaml), which has `kind: DefinitionStore` — not `kind: DataContract`. It contains reusable address structures with quality rules and common quality rules (email validation, phone format, amount checks).
+This example uses a companion file `0032-shared-definitions.yaml`, which has `kind: DefinitionStore` — not `kind: DataContract`. It contains reusable address structures with quality rules and common quality rules (email validation, phone format, amount checks).
 
-**0032-shared-definitions.yaml** (excerpt — see full file alongside this RFC):
+**0032-shared-definitions.yaml** (excerpt):
 ```yaml
 apiVersion: v3.2.0
 kind: DefinitionStore
@@ -1256,7 +1256,7 @@ Key observations:
 - The `DefinitionStore` organizes definitions by purpose (`address`, `quality`) rather than by the data contract schema structure. This makes it a natural fit for organization-wide libraries referenced from the declaration side.
 - The declaration side mixes imports from different sections of the same source: `#address/street_line_1` for properties, `#quality/email_validation` for quality rules.
 - On the use side, both **structural imports** (address fields with their quality rules) and **quality-only imports** (email validation, amount checks) are materialized inline with `$import` provenance.
-- The companion file [`0032-shared-definitions.yaml`](0032-shared-definitions.yaml) is provided alongside this RFC as a concrete reference.
+- The companion file `0032-shared-definitions.yaml` is shown as an excerpt above as a concrete reference.
 
 ### Applicability to ODPS
 

--- a/rfcs/0039-omds.md
+++ b/rfcs/0039-omds.md
@@ -518,5 +518,5 @@ The user noted "might be too free-form?" for Alternative 3 (unified diff format)
 - [RFC 6902 — JSON Patch](https://datatracker.ietf.org/doc/html/rfc6902) — Alternative considered.
 - [JSONPath specification](https://datatracker.ietf.org/doc/html/rfc9535) — Path notation candidate (RFC 9535).
 - [ODCS v3.0.0 / v3.1.0](https://github.com/bitol-io/open-data-contract-standard) — The standard this RFC applies to.
-- [ODPS v1.0.0 (RFC-0010)](../approved/odps-v0.9.0/0010-odps.md) — The companion standard supported via `sourceKind: DataProduct`.
+- [ODPS v1.0.0 (RFC-0010)](approved/odps-v0.9.0/0010-odps.md) — The companion standard supported via `sourceKind: DataProduct`.
 - Reference implementation: `ai.jgp.bitol.svc` — `ContractComparator`, `DiffResult`, `Diff` classes.

--- a/rfcs/0040-oocs.md
+++ b/rfcs/0040-oocs.md
@@ -447,7 +447,7 @@ Each sidecar could define its own configuration format. Rejected because it prev
 ## References
 
 - [ODCS — Open Data Contract Standard](https://bitol.io/open-data-contract-standard/) — What does the data look like?
-- [ODPS — Open Data Product Standard (RFC-0010)](../approved/odps-v0.9.0/0010-odps.md) — What is the data product?
+- [ODPS — Open Data Product Standard (RFC-0010)](approved/odps-v0.9.0/0010-odps.md) — What is the data product?
 - [OORS — Open Observability Results Standard (RFC-0018)](0018-oors.md) — What happened?
 - [OMDS — Open Metadata Difference Standard (RFC-0039)](0039-omds.md) — What changed?
 - [Kubernetes Resource Model](https://kubernetes.io/docs/concepts/overview/working-with-objects/) — Inspiration for `kind`, `apiVersion`, resource identity pattern.


### PR DESCRIPTION
Fixes pre-existing broken intra-repo links surfaced while building the RFC dashboard. All are in **open draft** RFCs (no spec/normative changes):

- **0039-omds.md**, **0040-oocs.md** — link to RFC-0010 used `../approved/…`, which escapes the `rfcs/` folder. Corrected to `approved/odps-v0.9.0/0010-odps.md`.
- **0032-imports.md** — two links pointed to a companion file `0032-shared-definitions.yaml` that does not exist in the repo (only an inline excerpt is shown). De-linked the references and pointed the prose at the inline excerpt rather than a non-existent file. If the champion wants a real companion file, it can be added later.

RFC-0047's `./…` links were also flagged by a checker but resolve correctly on GitHub — left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)