### PR TITLE
Add RFC 0056: Open Access Agreement Standard (OAAS)

### DIFF
--- a/rfcs/0056-oaas.md
+++ b/rfcs/0056-oaas.md
@@ -1,4 +1,4 @@
-# Open Data Access Agreement (ODAA)
+# Open Access Agreement Standard (OAAS)
 
 Champion: Simon Harrer.
 
@@ -16,19 +16,19 @@ Applies to:
 * [ ] OMMS - Open Maturity Model Standard
 * [ ] OMDS - Open Metadata Difference Standard
 * [ ] OSDS - Open Semantic Definition Standard
-* [x] ODAA - Open Data Access Agreement (new)
+* [x] OAAS - Open Access Agreement Standard (new)
 
 ## Summary
 
-ODAA (`kind: AccessAgreement`) records a 1:1 agreement between a data provider and a data consumer: who may access which output port, for what purpose, and for how long. It adapts the [Data Usage Agreement Specification](https://datausageagreement.com/) to Bitol conventions.
+OAAS (`kind: AccessAgreement`) records a 1:1 agreement between a data provider and a data consumer: who may access which output port, for what purpose, and for how long. It adapts the [Data Usage Agreement Specification](https://datausageagreement.com/) to Bitol conventions.
 
 ## Motivation
 
-ODCS describes what the data looks like, ODPS what the data product is. Neither records who may use it and why — that lives in tickets and spreadsheets today, unversioned and unauditable. ODAA makes the access grant a first-class artifact that tooling can provision from, auditors can read, and that expires on its own terms.
+ODCS describes what the data looks like, ODPS what the data product is. Neither records who may use it and why — that lives in tickets and spreadsheets today, unversioned and unauditable. OAAS makes the access grant a first-class artifact that tooling can provision from, auditors can read, and that expires on its own terms.
 
 ## Design and examples
 
-An ODAA document reuses the Bitol resource header (`apiVersion`, `kind`, `id`, `name`, `status`) and extension blocks (`tags`, `authoritativeDefinitions`, `customProperties`).
+An OAAS document reuses the Bitol resource header (`apiVersion`, `kind`, `id`, `name`, `status`) and extension blocks (`tags`, `authoritativeDefinitions`, `customProperties`).
 
 ### Example 1: Minimal
 
@@ -104,7 +104,7 @@ customProperties:
 
 | Field | Type | Required | Description |
 | ----- | ---- | -------- | ----------- |
-| `apiVersion` | string | yes | ODAA version. Initial version is `v0.9.0`. |
+| `apiVersion` | string | yes | OAAS version. Initial version is `v0.9.0`. |
 | `kind` | string | yes | Always `AccessAgreement`. |
 | `id` | string | yes | Unique identifier of the agreement. |
 | `name` | string | no | Human-readable label. |

--- a/rfcs/0056-odaa.md
+++ b/rfcs/0056-odaa.md
@@ -1,0 +1,152 @@
+# Open Data Access Agreement (ODAA)
+
+Champion: Simon Harrer.
+
+Authors: Simon Harrer.
+
+Slack: TBD.
+
+GitHub issue: TBD.
+
+Applies to:
+* [ ] ODCS - Open Data Contract Standard
+* [ ] ODPS - Open Data Product Standard
+* [ ] OORS - Open Observability Results Standard
+* [ ] OOCS - Open Orchestration and Control Standard
+* [ ] OMMS - Open Maturity Model Standard
+* [ ] OMDS - Open Metadata Difference Standard
+* [ ] OSDS - Open Semantic Definition Standard
+* [x] ODAA - Open Data Access Agreement (new)
+
+## Summary
+
+ODAA (`kind: AccessAgreement`) records a 1:1 agreement between a data provider and a data consumer: who may access which output port, for what purpose, and for how long. It adapts the [Data Usage Agreement Specification](https://datausageagreement.com/) to Bitol conventions.
+
+## Motivation
+
+ODCS describes what the data looks like, ODPS what the data product is. Neither records who may use it and why — that lives in tickets and spreadsheets today, unversioned and unauditable. ODAA makes the access grant a first-class artifact that tooling can provision from, auditors can read, and that expires on its own terms.
+
+## Design and examples
+
+An ODAA document reuses the Bitol resource header (`apiVersion`, `kind`, `id`, `name`, `status`) and extension blocks (`tags`, `authoritativeDefinitions`, `customProperties`).
+
+### Example 1: Minimal
+
+```yaml
+apiVersion: v0.9.0
+kind: AccessAgreement
+id: 8f5d1c2a-4b3e-4a91-9d7c-6e2f0a1b3c4d
+status: approved
+
+description:
+  purpose: Train the churn prediction model.
+
+startTimestamp: 2026-07-01T00:00:00Z
+
+provider:
+  teamId: sales
+  dataProductId: orders
+  outputPortId: orders_snowflake
+
+consumer:
+  teamId: marketing
+```
+
+### Example 2: Structured
+
+```yaml
+apiVersion: v0.9.0
+kind: AccessAgreement
+id: 8f5d1c2a-4b3e-4a91-9d7c-6e2f0a1b3c4d
+name: Orders for Realtime User Classification
+version: 1.1.0
+status: approved
+
+description:
+  purpose: Classify users in realtime based on their order history.
+  usage: Read-only access to aggregated order data for model inference.
+  limitations: No PII may be extracted. Results must not be resold to third parties.
+  terms: Free for the first three months.
+
+startTimestamp: 2026-07-01T00:00:00Z
+endTimestamp: 2027-06-30T23:59:59Z
+nextReassessmentTimestamp: 2027-01-01T00:00:00Z
+
+provider:
+  teamId: sales
+  dataProductId: orders
+  outputPortId: orders_snowflake
+  dataContractId: 4d2a7e10-9b6c-4f38-8a51-c7e3b9d0f2a6
+  dataContractVersion: 1.0.0
+
+consumer:
+  teamId: marketing
+  dataProductId: realtime_user_classification
+
+roles:
+  - role: orders.analyst.eu.read
+  - role: orders.analyst.us.read
+
+tags:
+  - gdpr-relevant
+
+authoritativeDefinitions:
+  - type: legalAgreement
+    url: https://acme.com/legal/dpa-marketing-2026.pdf
+    description: Signed data processing agreement covering this grant.
+
+customProperties:
+  - property: costCenter
+    value: MKT-4711
+```
+
+### Fields
+
+| Field | Type | Required | Description |
+| ----- | ---- | -------- | ----------- |
+| `apiVersion` | string | yes | ODAA version. Initial version is `v0.9.0`. |
+| `kind` | string | yes | Always `AccessAgreement`. |
+| `id` | string | yes | Unique identifier of the agreement. |
+| `name` | string | no | Human-readable label. |
+| `version` | string (semver) | no | Version of this document. Bump when terms change. |
+| `status` | enum | yes | `requested`, `approved`, `rejected`. |
+| `startTimestamp` | timestamp | no | When the grant takes effect. RFC 3339 in UTC (`Z`). |
+| `endTimestamp` | timestamp | no | When the grant expires. Omit for open-ended grants. |
+| `nextReassessmentTimestamp` | timestamp | no | When the grant must next be reviewed. |
+| `description.purpose` | string | yes | Why the consumer needs the data. |
+| `description.usage` | string | no | What the consumer may do with it. |
+| `description.limitations` | string | no | Restrictions on the grant. |
+| `description.terms` | string | no | Commercial or contractual terms, e.g. pricing. |
+| `provider.teamId` | string | yes | Team owning the data product. |
+| `provider.dataProductId` | string | yes | ODPS data product being accessed. |
+| `provider.outputPortId` | string | yes | Output port being accessed. |
+| `provider.dataContractId` | string | no | ODCS contract governing the port. |
+| `provider.dataContractVersion` | string (semver) | no | Contract version the grant was agreed against. |
+| `consumer.teamId` | string | no | Consuming team. |
+| `consumer.dataProductId` | string | no | Consuming ODPS data product. Requires `teamId`. |
+| `consumer.userId` | string | no | Consuming individual, e.g. an email address. |
+| `roles` | array | no | Provider roles granted to the consumer. ODCS semantics. |
+| `roles[].role` | string | yes* | Role name in the provider's access system (*required within each entry). |
+| `tags` | array of string | no | Free-form labels. |
+| `authoritativeDefinitions` | array | no | Typed links to external sources. ODCS semantics. |
+| `customProperties` | array | no | Platform-specific data. ODCS semantics. |
+
+At least one `consumer` field must be set. A data product consumer enables lineage; a team or user consumer covers ad-hoc access.
+
+## Alternatives
+
+TBD
+
+## Decision
+
+> The decision made by the TSC.
+
+## Consequences
+
+- New standard; no changes to ODCS or ODPS.
+
+## References
+
+- [Data Usage Agreement Specification](https://datausageagreement.com/) — prior art this RFC adapts.
+- [ODCS](https://bitol-io.github.io/open-data-contract-standard/) — header, `description`, `authoritativeDefinitions`, `customProperties`.
+- [ODPS](https://bitol-io.github.io/open-data-product-standard/) — `dataProductId`, `outputPortId`.

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -34,6 +34,7 @@ Proposed or under discussion — not yet approved by the TSC. These are what rem
 | [0049](0049-iceberg-server-type.md) | Apache Iceberg server type |
 | [0050](0050-variables.md) | Variables |
 | [0052](0052-blob-storage-file-logical-type.md) | Schema's Blob logicalType |
+| [0056](0056-odaa.md) | Open Data Access Agreement (ODAA) |
 
 ## Approved RFCs
 

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -34,7 +34,7 @@ Proposed or under discussion — not yet approved by the TSC. These are what rem
 | [0049](0049-iceberg-server-type.md) | Apache Iceberg server type |
 | [0050](0050-variables.md) | Variables |
 | [0052](0052-blob-storage-file-logical-type.md) | Schema's Blob logicalType |
-| [0056](0056-odaa.md) | Open Data Access Agreement (ODAA) |
+| [0056](0056-oaas.md) | Open Access Agreement Standard (OAAS) |
 
 ## Approved RFCs
 


### PR DESCRIPTION
Introduces **OAAS** (`kind: AccessAgreement`), a new Bitol standard for recording a 1:1 access grant between a data provider's output port and a data consumer: who may access what, for what purpose, and for how long.

ODCS describes what the data looks like and ODPS what the data product is. Neither records who may use it and why.