### PR TITLE
Add RFC 0057: Teradata server type

### DIFF
--- a/rfcs/0057-teradata-server-type.md
+++ b/rfcs/0057-teradata-server-type.md
@@ -1,0 +1,58 @@
+# Teradata server type
+
+Champion: Simon Harrer
+
+Contributors:
+* Martin Hillebrand
+
+Applies to:
+* [x] ODCS - Open Data Contract Standard
+* [ ] ODPS - Open Data Product Standard
+* [ ] OORS - Open Observability Results Standard
+* [ ] OOCS - Open Orchestration and Control Standard
+* [ ] OMMS - Open Maturity Model Standard
+* [ ] OMDS - Open Metadata Difference Standard
+
+## Summary
+
+Add `teradata` as a server `type` to describe data served from Teradata Vantage.
+
+## Motivation
+
+Teradata Vantage is a widely used enterprise data warehouse, but ODCS has no server type for it. Users fall back to `custom`, losing structured, validatable connection metadata.
+
+## Design and examples
+
+| Field      | Type   | Required | Description                        |
+| ---------- | ------ | -------- | ---------------------------------- |
+| `type`     | string | Yes      | `teradata`                         |
+| `host`     | string | Yes      | Host of the Teradata server.       |
+| `port`     | number | No       | Port, defaults to `1025`.          |
+| `database` | string | No       | Name of the database.              |
+
+No `schema` field: in Teradata, the database is the namespace.
+
+```yaml
+servers:
+  - server: prod
+    type: teradata
+    host: teradata.acme.com
+    port: 1025
+    database: SALES
+```
+
+## Alternatives
+
+Keep using `custom`. Rejected: hides connection details in unstructured fields.
+
+## Decision
+
+> The decision made by the TSC.
+
+## Consequences
+
+- nonbreaking change: adds a new optional server type.
+
+## References
+
+- [Teradata Vantage documentation](https://docs.teradata.com/)

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -33,6 +33,7 @@ Proposed or under discussion — not yet approved by the TSC. These are what rem
 | [0052](0052-blob-storage-file-logical-type.md) | Schema's Blob logicalType |
 | [0053](0053-classification-sensitivity.md) | Data category as a distinct dimension |
 | [0056](0056-oaas.md) | Open Access Agreement Standard (OAAS) |
+| [0057](0057-teradata-server-type.md) | Teradata server type |
 
 ## Approved RFCs
 


### PR DESCRIPTION
Adds `teradata` as a server `type` to ODCS, following RFC 0045 (HANA server type) as a structural template.

- Champion: Simon Harrer
- Contributor: Martin Hillebrand
- Fields: `host` (required), `port` (defaults to 1025), `database`

No `schema` field: Teradata has no schema layer distinct from databases — a database directly contains tables and views and serves as the namespace.

Also lists the RFC under Open RFCs in the dashboard.