### PR TITLE
Add RFC 0058: Exasol server type

### DIFF
--- a/rfcs/0058-exasol-server-type.md
+++ b/rfcs/0058-exasol-server-type.md
@@ -1,0 +1,55 @@
+# Exasol server type
+
+Champion: Jochen Christ
+
+Applies to:
+* [x] ODCS - Open Data Contract Standard
+* [ ] ODPS - Open Data Product Standard
+* [ ] OORS - Open Observability Results Standard
+* [ ] OOCS - Open Orchestration and Control Standard
+* [ ] OMMS - Open Maturity Model Standard
+* [ ] OMDS - Open Metadata Difference Standard
+
+## Summary
+
+Add `exasol` as a server `type` to describe data served from Exasol.
+
+## Motivation
+
+Exasol is an in-memory MPP analytics database used as an enterprise data warehouse, but ODCS has no server type for it. Users fall back to `custom`, losing structured, validatable connection metadata.
+
+## Design and examples
+
+| Field    | Type   | Required | Description                                                                          |
+| -------- | ------ | -------- | ------------------------------------------------------------------------------------ |
+| `type`   | string | Yes      | `exasol`                                                                             |
+| `host`   | string | Yes      | Host of the Exasol server. May be a cluster connection range, e.g. `n11..14.acme.com`. |
+| `port`   | number | No       | Port, defaults to `8563`.                                                            |
+| `schema` | string | No       | Name of the schema.                                                                  |
+
+No `database` field: an Exasol cluster runs a single database, and the schema is the namespace.
+
+```yaml
+servers:
+  - server: prod
+    type: exasol
+    host: exasol.acme.com
+    port: 8563
+    schema: SALES
+```
+
+## Alternatives
+
+Keep using `custom`. Rejected: hides connection details in unstructured fields.
+
+## Decision
+
+> The decision made by the TSC.
+
+## Consequences
+
+- nonbreaking change: adds a new optional server type.
+
+## References
+
+- [Exasol documentation](https://docs.exasol.com/)

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -34,6 +34,7 @@ Proposed or under discussion — not yet approved by the TSC. These are what rem
 | [0053](0053-classification-sensitivity.md) | Data category as a distinct dimension |
 | [0056](0056-oaas.md) | Open Access Agreement Standard (OAAS) |
 | [0057](0057-teradata-server-type.md) | Teradata server type |
+| [0058](0058-exasol-server-type.md) | Exasol server type |
 
 ## Approved RFCs
 


### PR DESCRIPTION
Adds `exasol` as a server `type` for ODCS, following the pattern of RFC 0057 (Teradata) and RFC 0045 (HANA).

Fields: `host` (required, may be a cluster connection range), `port` (defaults to 8563), `schema`. No `database` field, since an Exasol cluster runs a single database and the schema is the namespace.

Nonbreaking: adds a new optional server type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)